### PR TITLE
Potential fix for code scanning alert no. 24: Clear-text logging of sensitive information

### DIFF
--- a/src/modules/comrex-briclink/container/utils/comrex-socket.js
+++ b/src/modules/comrex-briclink/container/utils/comrex-socket.js
@@ -72,7 +72,7 @@ class ComrexSocket extends EventEmitter {
                             await delay(10000);
                         }
                         console.log(
-                            `comrex-socket: logging in with credentials: ${self.opts.username} / ${self.opts.password}`
+                            `comrex-socket: attempting to log in with provided credentials`
                         );
 
                         // this is what comrex require to log into the device

--- a/src/modules/tsl-mdu/container/utils/basic-auth.js
+++ b/src/modules/tsl-mdu/container/utils/basic-auth.js
@@ -8,7 +8,7 @@ module.exports = async ({ host, username, password, timeout = 5000 }) => {
         if (!host.includes("http://") || !host.includes("https://")) {
             host = "http://" + host;
         }
-        console.log(`${username}:${password}`);
+        console.log(`Attempting authentication for user: ${username}`);
         response = await axios.get(host, {
             timeout: timeout,
             auth: {


### PR DESCRIPTION
Potential fix for [https://github.com/bbc/bug/security/code-scanning/24](https://github.com/bbc/bug/security/code-scanning/24)

To fix the issue, we will remove the logging of sensitive information (`username` and `password`) on line 11. If logging is necessary for debugging purposes, we can log a sanitized or masked version of the data (e.g., only the username or a masked password). Additionally, we will ensure that no sensitive information is logged elsewhere in the code.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
